### PR TITLE
Env support

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+REACT_APP_API_HOST=https://tasks-api.tomestone.dev
+REACT_APP_HOST=http://localhost:3000

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+REACT_APP_HOST=https://tasks.tomestone.dev

--- a/.env.staging
+++ b/.env.staging
@@ -1,0 +1,1 @@
+REACT_APP_HOST=https://tasks-staging.tomestone.dev

--- a/cdk/index.ts
+++ b/cdk/index.ts
@@ -9,6 +9,7 @@ const app = new cdk.App();
 const staging = new PipelineStack(app, "Staging-DeliveryPipeline", {
     name: "App-Staging",
     branch: "develop",
+    buildCommand: "build:staging"
 });
 
 const stagingStage = new FrontEndStage(app, "Staging-App", {

--- a/cdk/pipeline-stack.ts
+++ b/cdk/pipeline-stack.ts
@@ -7,6 +7,7 @@ import {pipelines, aws_codepipeline as codepipeline, aws_codepipeline_actions as
 export interface PipelineStackProps extends cdk.StackProps {
   name: string;
   branch: string;
+  buildCommand?: string;
 }
 
 export class PipelineStack extends cdk.Stack {
@@ -17,6 +18,8 @@ export class PipelineStack extends cdk.Stack {
 
     const sourceArtifact = new codepipeline.Artifact();
     const cloudAssemblyArtifact = new codepipeline.Artifact();
+
+    const buildCommand = props.buildCommand || 'build';
 
     this.pipeline = new pipelines.CdkPipeline(this, "Pipeline", {
       pipelineName: `${props.name}-DeliveryPipeline`,
@@ -33,7 +36,7 @@ export class PipelineStack extends cdk.Stack {
       synthAction: pipelines.SimpleSynthAction.standardNpmSynth({
         sourceArtifact,
         cloudAssemblyArtifact,
-        buildCommand: 'npm run build && npm run cdk-build',
+        buildCommand: `npm run ${buildCommand} && npm run cdk-build`,
       }),
     });
   }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "build:staging": "sh -ac '. .env.staging; react-scripts build'",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "cdk-build": "tsc --target ES2018 --moduleResolution node --module commonjs cdk/index.ts",

--- a/src/components/login.jsx
+++ b/src/components/login.jsx
@@ -6,7 +6,7 @@ export default function Login() {
         <div className="container link-page">
             <Row justify="space-around">
                 <Col className="splash-box">
-                    <a href={`${apiBaseUrl}login`}><img alt="Login" src="/images/discordlogin.png"/></a>
+                    <a href={`${apiBaseUrl}/login?redirect=${process.env.REACT_APP_HOST}`}><img alt="Login" src="/images/discordlogin.png"/></a>
                 </Col>
             </Row>
         </div>

--- a/src/services/tracker.ts
+++ b/src/services/tracker.ts
@@ -1,6 +1,6 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 
-export const apiBaseUrl = 'https://tasks-api.tomestone.dev/';
+export const apiBaseUrl = process.env.REACT_APP_API_HOST;
 
 // Define a service using a base URL and expected endpoints
 export const trackerApi = createApi({


### PR DESCRIPTION
Add support for 3 environments: local (default), staging, and production. Each point to the same API (for now) but have their own unique host set. This is used during login so that we can redirect users back to the correct host.